### PR TITLE
Split book_pid and output namespace and book directories.

### DIFF
--- a/src/moldybreadpkg/fedora.nim
+++ b/src/moldybreadpkg/fedora.nim
@@ -230,10 +230,14 @@ method download(this: FedoraRecord, output_directory: string, suffix=""): bool {
 method download_page_with_relationship(this: FedoraRecord, output_directory, book_pid, page_number: string): bool {. base .} =
   let response = this.client.request(this.uri, httpMethod = HttpGet)
   if response.status == "200 OK":
-    let extension = this.get_extension(response.headers)
-    if not existsDir(fmt"{output_directory}/{book_pid}"):
-      createDir(fmt"{output_directory}/{book_pid}")
-    discard this.write_output(fmt"{page_number}{extension}", response.body, fmt"{output_directory}/{book_pid}")
+    let 
+      extension = this.get_extension(response.headers)
+      namespace = book_pid.split(""":""")[0]
+      book = book_pid.split(""":""")[1]
+      output_path = fmt"{output_directory}/{namespace}/{book}"
+    if not existsDir(output_path):
+      createDir(output_path)
+    discard this.write_output(fmt"{page_number}{extension}", response.body, output_path)
     true
   else:
     false


### PR DESCRIPTION
**GitHub Issue**: [[FEATURE] Output by namespace when downloading pages with relationships](https://github.com/markpbaggett/moldybread/issues/5)

What Does this Do?
==================

Splits `book_pid` and creates a directory for the namespace at the top level of the directory_path defined by config.yml. All book directories and relative filename.ext are contained to this directory.

How Should This Be Tested?
==========================

1. `moldybread -o download_book_pages -n namespace -d OBJ`
2. Book directories will output in directory titled the same as the relative namespace
3. filename.ext will output in the book directories

Example
```
|-- namespace
   |-- book_1
      |-- 1.tif
      |-- 2.tif
   |-- book_2
      |-- 1.tif
      |-- 2.tif
```

Additional Notes
================

I'm addressing my own issue here, but feel like it's okay as we've previously discussed this one.