### PR TITLE
Populate refine

### DIFF
--- a/src/moldybreadpkg/fedora.nim
+++ b/src/moldybreadpkg/fedora.nim
@@ -367,7 +367,7 @@ method populate_results*(this: FedoraRequest): seq[string] {. base .} =
       stdout.write("->")
       response = this.client.request(request, httpMethod = HttpGet)
       if response.status == "200 OK":
-        notice(fmt"Successfully retrieved {this.uri} and contents for {this.pid}.")
+        notice(fmt"Successfully retrieved.")
         new_pids = this.grab_pids(response.body)
         for pid in new_pids:
           result.add(pid)
@@ -375,7 +375,7 @@ method populate_results*(this: FedoraRequest): seq[string] {. base .} =
         request = fmt"{base_request}&sessionToken={token}"
         stdout.flushFile()
       else:
-        error(fmt"{response.status}: FedoraRequest.get() failed on {this.pid}.")
+        error(fmt"{response.status}: Method populate_results failed.")
     except OSError:
       echo "Can't connect to host"
       break

--- a/src/moldybreadpkg/fedora.nim
+++ b/src/moldybreadpkg/fedora.nim
@@ -349,7 +349,7 @@ method populate_results*(this: FedoraRequest): seq[string] {. base .} =
     new_pids: seq[string] = @[]
     token: string = "temporary"
     request, base_request: string
-    response : Response
+    response: Response
   echo "\nFinding matching objects.  This may take a while.\n"
   if this.dc_values != "":
     let dc_stuff = convert_dc_pairs_to_string(this.dc_values)
@@ -373,9 +373,9 @@ method populate_results*(this: FedoraRequest): seq[string] {. base .} =
           result.add(pid)
         token = this.get_token(response.body)
         request = fmt"{base_request}&sessionToken={token}"
-        stdout.flushFile()
       else:
-        error(fmt"{response.status}: Method populate_results failed on {request}.")
+        fatal(fmt"{response.status}: Method populate_results failed on {request}.")
+      stdout.flushFile()
     except OSError:
       echo "Can't connect to host"
       break

--- a/src/moldybreadpkg/fedora.nim
+++ b/src/moldybreadpkg/fedora.nim
@@ -367,7 +367,7 @@ method populate_results*(this: FedoraRequest): seq[string] {. base .} =
       stdout.write("->")
       response = this.client.request(request, httpMethod = HttpGet)
       if response.status == "200 OK":
-        notice(fmt"Successfully retrieved.")
+        notice(fmt"Successfully retrieved populate_results {request}.")
         new_pids = this.grab_pids(response.body)
         for pid in new_pids:
           result.add(pid)
@@ -375,7 +375,7 @@ method populate_results*(this: FedoraRequest): seq[string] {. base .} =
         request = fmt"{base_request}&sessionToken={token}"
         stdout.flushFile()
       else:
-        error(fmt"{response.status}: Method populate_results failed.")
+        error(fmt"{response.status}: Method populate_results failed on {request}.")
     except OSError:
       echo "Can't connect to host"
       break


### PR DESCRIPTION
**GitHub Issue**: [[BUG] populate_results() allows non 200 responses to fail silently bug #9](https://github.com/markpbaggett/moldybread/issues/9)

What Does this Do?
==================

Removes `getContent` procedure from the `populate_results` method and uses `client.request` instead. We then add a conditional based on the response.status, adding logging, and error reporting on non-200 response status.

How Should This Be Tested?
==========================

1. Test any moldybread command that uses populate_results such as `moldybread -o download_book_pages -n agrtfn -d OBJ`
2. The moldybread.log will contain all responses from the **populate_results**


Additional Notes
================
To get this to fail, the easiest thing to do is the screw with the request or base_request vars.