### PR TITLE
Address issue 4.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -9,9 +9,9 @@ Moldy Bread Change Log
 
 * A file logger has been added based on Nim's default logging library.  For now, it logs all levels and is partially configurable within config.yml.
 
-**Changes to FedoraRequest**:
+**Changes to FedoraRecord**:
 
-* FedoraRequest now has 2 additional attributes: wait_time and retries.  These are there so you can declare a value for the number of times a method on FedoraRequest should be retried before in results in a `fatal` failure.  wait_time allows you to set the amount of milliseconds to wait before retrying.
+* FedoraRecord now has 2 additional attributes: wait_time and retries.  These are there so you can declare a value for the number of times a method on FedoraRequest should be retried before in results in a `fatal` failure.  wait_time allows you to set the amount of milliseconds to wait before retrying.
 
 0.1.5 - May 13, 2020
 ======================================

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,10 @@ Moldy Bread Change Log
 
 * A file logger has been added based on Nim's default logging library.  For now, it logs all levels and is partially configurable within config.yml.
 
+**Changes to FedoraRequest**:
+
+* FedoraRequest now has 2 additional attributes: wait_time and retries.  These are there so you can declare a value for the number of times a method on FedoraRequest should be retried before in results in a `fatal` failure.  wait_time allows you to set the amount of milliseconds to wait before retrying.
+
 0.1.5 - May 13, 2020
 ======================================
 

--- a/src/moldybreadpkg/fedora.nim
+++ b/src/moldybreadpkg/fedora.nim
@@ -244,7 +244,7 @@ method download_page_with_relationship(this: FedoraRecord, output_directory, boo
     true
   elif this.retries > 0:
     this.retries -= 1
-    error(fmt"Failed to download page {page_number} of {book_pid} from {this.pid}.")
+    error(fmt"{response.status} - Failed to download page {page_number} of {book_pid} from {this.pid}.")
     sleep(this.wait_time)
     this.download_page_with_relationship(output_directory, book_pid, page_number)
   else:

--- a/src/moldybreadpkg/fedora.nim
+++ b/src/moldybreadpkg/fedora.nim
@@ -466,9 +466,9 @@ method download_page_with_book_relationship*(this: FedoraRequest, datastream_id:
     if response != "":
       let
         book = newTriple(response).obj.replace("<info:fedora/", "").replace(">", "")
-        page_triple = FedoraRecord(client: this.client, uri: fmt"{this.base_url}/fedora/objects/{pid}/relationships?subject=info%3afedora%2f{pid}&format=turtle&predicate=http://islandora.ca/ontology/relsext%23isPageNumber", pid: pid).get()
+        page_triple = FedoraRecord(client: this.client, uri: fmt"{this.base_url}/fedora/objects/{pid}/relationships?subject=info%3afedora%2f{pid}&format=turtle&predicate=http://islandora.ca/ontology/relsext%23isPageNumber", pid: pid, retries: 3, wait_time: 3000).get()
         page = newTriple(page_triple).obj.replace(""""""", "")
-      discard FedoraRecord(client: this.client, uri: fmt"{this.base_url}/fedora/objects/{pid}/datastreams/{datastream_id}/content", pid: pid).download_page_with_relationship(this.output_directory, book, page)
+      discard FedoraRecord(client: this.client, uri: fmt"{this.base_url}/fedora/objects/{pid}/datastreams/{datastream_id}/content", pid: pid, retries: 3, wait_time: 3000).download_page_with_relationship(this.output_directory, book, page)
       result.add((book, page, pid))
     if i in ticks:
       bar.increment()


### PR DESCRIPTION
**GitHub Issue**: [Issue 4](https://github.com/markpbaggett/moldybread/issues/4)

What Does this Do?
==================

This pull request attempts to address issue 4 by:

1. Adding scaffolding for waits and retries on the FedoraRecord type
2. Refactoring FedoraRecord.download_page_with_relationship() to take advantage of these new attributes.  Now, if the method results in a non-"200 OK", an error is recorded to the log with the status code and status message and the associated resource.  The request will be retried until the value of FedoraRecord.retries <= 0. If the number of retries is met, a fatal message is recorded to log and False is passed back from the request.
3. The places where this method is being called have been refactored to ensure that FedoraRecord.wait_time and FedoraRecord.retries has a value.


How Should This Be Tested?
==========================

Run this and hope something fails?

Additional Notes
================

We don't have a constructor for Fedora record.  Should we? Also, this can't be set from yaml yet.
